### PR TITLE
Make the footer stay at the bottom of the page

### DIFF
--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -55,7 +55,7 @@
   </tr>
 </table>
 	</div>
-	{{{menu}}}
+	
 <script type="text/javascript" src="/js/addOrder.js"></script>
 <script type="text/javascript" src="/js/food-menu-dashboard.js"></script>
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,4 +1,8 @@
 /*{}*/
+html {
+    position: relative;
+    min-height: 100%;
+}
 
 body {
   font-family: Arial, Helvetica, sans-serif;
@@ -7,6 +11,7 @@ body {
   padding: 0;
   margin: 0;
   background-color: #f4f4f4;
+  margin: 0 0 100px;
 }
 /*Global*/
 .container {
@@ -184,6 +189,12 @@ footer {
   color: #ffffff;
   background-color: #403737;
   text-align: center;
+
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 50px;
+    width: 97%;
 }
 
 /*Main-col*/


### PR DESCRIPTION
When there isn't a lot of contents on a page, the footer goes up thereby
leaving, making the page look untidy.

This commit addresses that and ensures the footer stays where it's
supposed to, regardless of page contents