### PR TITLE
Make the footer stay at the bottom of the page

### DIFF
--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -55,7 +55,7 @@
   </tr>
 </table>
 	</div>
-	
+
 <script type="text/javascript" src="/js/addOrder.js"></script>
 <script type="text/javascript" src="/js/food-menu-dashboard.js"></script>
 


### PR DESCRIPTION
This PR will ensure that the footer stays at the bottom of the screen, even with varying page contents. Currently, the footer has the tendency to 'jump' or move up the screen when ever a page that has few contents is viewed.

This can be tested out by checking the hosted site here, https://dokenedgar.herokuapp.com/ 
A snapshot of the new change can be seen below.
Associated PT Story:
Footer goes up when a page doesn't have much contents 
Number:#160801886

![footer](https://user-images.githubusercontent.com/25203963/46101651-6ceca900-c1c4-11e8-9ed3-5e16a5ec8438.JPG)
